### PR TITLE
631: Set up template repository to use npm libraries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
             "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
+            "oomphinc/composer-installers-extender": true,
             "php-http/discovery": true,
             "phpstan/extension-installer": true
         },
@@ -74,9 +75,10 @@
                 "web-root": "web/"
             }
         },
+        "installer-types": ["npm-asset"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/libraries/{$name}": ["type:drupal-library", "type:npm-asset"],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],


### PR DESCRIPTION
First step for https://github.com/MukurtuCMS/Mukurtu-CMS/issues/631.

This sets up the template repository to be able to use npm packages through composer. See https://drupaljournal.com/gist/install-npm-and-bower-packages-using-composer-drupal for detailed description of how this works.

But unlike that blog post, this is only adding support for `npm`, since `bower` is now a discontinued product (although it continues to work for the time being). We should move forward with using `npm`, since it seems to have won the package manager war.